### PR TITLE
Permit rabbit config to be outside of nested rates & queue description

### DIFF
--- a/lib/peluquera.ex
+++ b/lib/peluquera.ex
@@ -19,15 +19,20 @@ defmodule Peluquera do
   def init(args) do
     peluquerias = Application.get_env(:peluquero, :peluquerias, [])
     peinados = Application.get_env(:peluquero, :peinados, [])
+    rabbit = Application.get_env(:peluquero, :rabbit, [])
 
     Logger.warn(fn ->
       "✂ Peluquero started:\n" <>
         "   — peluquerias: #{inspect(peluquerias)}.\n" <>
+        "   — rabbit: #{inspect(rabbit)}.\n" <>
         "   — peinados: #{inspect(peinados)}.\n" <> "   — args: #{inspect(args)}.\n\n"
     end)
 
     amqps =
-      case Enum.map(peluquerias, &spec_for_peluqueria/1) do
+      peluquerias
+      |> Enum.map(&add_rabbit_conf_to_peluqueria(rabbit, &1))
+      |> Enum.map(&spec_for_peluqueria/1)
+      |> case do
         [] -> [{Peluquero.Peluqueria, []}]
         many -> many
       end
@@ -40,6 +45,11 @@ defmodule Peluquera do
   def suicide, do: GenServer.cast(__MODULE__, :suicide)
 
   ##############################################################################
+
+  defp add_rabbit_conf_to_peluqueria([], {exchg, conf}), do: {exchg, conf}
+
+  defp add_rabbit_conf_to_peluqueria(rabbit, {exchg, conf}),
+    do: {exchg, Keyword.merge(conf, rabbit: rabbit)}
 
   defp spec_for_peluqueria({name, settings}) do
     %{

--- a/lib/peluquera.ex
+++ b/lib/peluquera.ex
@@ -19,7 +19,7 @@ defmodule Peluquera do
   def init(args) do
     peluquerias = Application.get_env(:peluquero, :peluquerias, [])
     peinados = Application.get_env(:peluquero, :peinados, [])
-    rabbit = Application.get_env(:peluquero, :rabbit, [])
+    rabbit = Application.get_env(:peluquero, :rabbit, nil)
 
     Logger.warn(fn ->
       "✂ Peluquero started:\n" <>
@@ -30,7 +30,6 @@ defmodule Peluquera do
 
     amqps =
       peluquerias
-      |> Enum.map(&add_rabbit_conf_to_peluqueria(rabbit, &1))
       |> Enum.map(&spec_for_peluqueria/1)
       |> case do
         [] -> [{Peluquero.Peluqueria, []}]
@@ -45,11 +44,6 @@ defmodule Peluquera do
   def suicide, do: GenServer.cast(__MODULE__, :suicide)
 
   ##############################################################################
-
-  defp add_rabbit_conf_to_peluqueria([], {exchg, conf}), do: {exchg, conf}
-
-  defp add_rabbit_conf_to_peluqueria(rabbit, {exchg, conf}),
-    do: {exchg, Keyword.merge(conf, rabbit: rabbit)}
 
   defp spec_for_peluqueria({name, settings}) do
     %{

--- a/lib/peluquera.ex
+++ b/lib/peluquera.ex
@@ -24,7 +24,7 @@ defmodule Peluquera do
     Logger.warn(fn ->
       "✂ Peluquero started:\n" <>
         "   — peluquerias: #{inspect(peluquerias)}.\n" <>
-        "   — rabbit: #{inspect(rabbit)}.\n" <>
+        "   — default rabbit: #{inspect(rabbit)}.\n" <>
         "   — peinados: #{inspect(peinados)}.\n" <> "   — args: #{inspect(args)}.\n\n"
     end)
 

--- a/lib/peluquero/peluqueria.ex
+++ b/lib/peluquero/peluqueria.ex
@@ -11,7 +11,6 @@ defmodule Peluquero.Peluqueria do
   @rabbits Application.get_env(:peluquero, :rabbits, 1)
   @opts Application.get_env(:peluquero, :opts, [])
   @consul Application.get_env(:peluquero, :consul, nil)
-  @rabbit Application.get_env(:peluquero, :rabbit, nil)
   @pool Application.get_env(:peluquero, :pool, [])
 
   defmodule Chairs do
@@ -108,7 +107,7 @@ defmodule Peluquero.Peluqueria do
               name: name,
               opts: opts[:opts] || @opts,
               consul: opts[:consul] || @consul,
-              rabbit: opts[:rabbit] || @rabbit
+              rabbit: opts[:rabbit] || Application.get_env(:peluquero, :rabbit, nil)
             ]
           ],
           id: name


### PR DESCRIPTION
Newer versions of Elixir offer the possibility of loading configurations at runtime instead of build-time (using `config.releases.exs`). 

This mod introduces this capability for projects where more than one type of production environment is needed.